### PR TITLE
attr('checked', 'checked') did not work for me

### DIFF
--- a/src/jquery.deserialize.js
+++ b/src/jquery.deserialize.js
@@ -60,7 +60,7 @@
 		for( key in kv ){
 			value = kv[key];
 			
-			$('input[type="checkbox"][name="'+ key +'"][value="'+ value +'"],input[type="radio"][name="'+ key +'"][value="'+ value +'"]', element).attr('checked', 'checked');
+			$('input[type="checkbox"][name="'+ key +'"][value="'+ value +'"],input[type="radio"][name="'+ key +'"][value="'+ value +'"]', element).prop('checked', true);
 			$('select[name="'+ key +'"],input[type="text"][name="'+ key +'"],input[type="password"][name="'+ key +'"],input[type="hidden"][name="'+ key +'"],textarea[name="'+ key +'"]', element).val(value);
 		}
 	}


### PR DESCRIPTION
I use jQuery version 2+
I quote from jQuery website: The difference between attributes and properties can be important in specific situations. Before jQuery 1.6, the .attr() method sometimes took property values into account when retrieving some attributes, which could cause inconsistent behavior. As of jQuery 1.6, the .prop() method provides a way to explicitly retrieve property values, while .attr() retrieves attributes.

BTW, awesome plugin! :+1: was looking for a good one everywhere
